### PR TITLE
pyqt not compatible with anaconda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,5 @@ setup(
         'pyqtgraph>=0.10.0',
         'matplotlib',
         'numpy',
-        'pyqt5>=5.9.0',
     ],
 )


### PR DESCRIPTION
we shouldn't list pyqt at all as pip-dependency. this seems to not work well with anaconda. using only pyqtgraph is enough for now.