### PR TITLE
Full complex options buttons

### DIFF
--- a/plottr/plot/base.py
+++ b/plottr/plot/base.py
@@ -249,6 +249,9 @@ class ComplexRepresentation(Enum):
     #: real and imaginary
     realAndImag = auto()
 
+    #: real and imaginary, separated
+    realAndImagSeparate = auto()
+
     #: magnitude and phase
     magAndPhase = auto()
 
@@ -405,7 +408,18 @@ class AutoFigureMaker(object):
         if not np.issubsctype(plotItem.data[-1], np.complexfloating):
             return [plotItem]
 
-        elif self.complexRepresentation is ComplexRepresentation.realAndImag:
+        elif self.complexRepresentation is ComplexRepresentation.real:
+            plotItem.data[-1] = plotItem.data[-1].real
+            assert isinstance(plotItem.labels, list)
+            if label == '':
+                plotItem.labels[-1] = 'Real'
+            else:
+                plotItem.labels[-1] = label + ' (Real)'
+            return [plotItem]
+
+        elif self.complexRepresentation in \
+                [ComplexRepresentation.realAndImag, ComplexRepresentation.realAndImagSeparate]:
+
             re_data = plotItem.data[-1].real
             im_data = plotItem.data[-1].imag
 
@@ -421,8 +435,8 @@ class AutoFigureMaker(object):
             im_plotItem.data[-1] = im_data
             im_plotItem.id = re_plotItem.id + 1
 
-            # TODO: think whether this is universal or might depend on the backend?
-            if len(plotItem.data) > 2:
+            if self.complexRepresentation == ComplexRepresentation.realAndImagSeparate \
+                    or len(plotItem.data) > 2:
                 im_plotItem.subPlot = re_plotItem.subPlot + 1
 
             # this is a bit of a silly check (see top of the function -- should certainly be True!).

--- a/plottr/plot/mpl/autoplot.py
+++ b/plottr/plot/mpl/autoplot.py
@@ -151,7 +151,7 @@ class AutoPlotToolBar(QtWidgets.QToolBar):
     plotTypeSelected = Signal(PlotType)
 
     #: signal emitted when the complex data option has been changed
-    complexPolarSelected = Signal(ComplexRepresentation)
+    complexRepresentationSelected = Signal(ComplexRepresentation)
 
     def __init__(self, name: str, parent: Optional[QtWidgets.QWidget] = None):
         """Constructor for :class:`AutoPlotToolBar`"""
@@ -198,10 +198,15 @@ class AutoPlotToolBar(QtWidgets.QToolBar):
         self.plotReal.triggered.connect(
             lambda: self.selectComplexType(ComplexRepresentation.real))
 
-        self.plotReIm = self.addAction('Real/Imag')
+        self.plotReIm = self.addAction('Re/Im')
         self.plotReIm.setCheckable(True)
         self.plotReIm.triggered.connect(
             lambda: self.selectComplexType(ComplexRepresentation.realAndImag))
+
+        self.plotReImSep = self.addAction('Split Re/Im')
+        self.plotReImSep.setCheckable(True)
+        self.plotReImSep.triggered.connect(
+            lambda: self.selectComplexType(ComplexRepresentation.realAndImagSeparate))
 
         self.plotMagPhase = self.addAction('Mag/Phase')
         self.plotMagPhase.setCheckable(True)
@@ -219,6 +224,7 @@ class AutoPlotToolBar(QtWidgets.QToolBar):
         self.ComplexActions = OrderedDict({
             ComplexRepresentation.real: self.plotReal,
             ComplexRepresentation.realAndImag: self.plotReIm,
+            ComplexRepresentation.realAndImagSeparate: self.plotReImSep,
             ComplexRepresentation.magAndPhase: self.plotMagPhase
         })
 
@@ -254,7 +260,7 @@ class AutoPlotToolBar(QtWidgets.QToolBar):
             self.plotTypeSelected.emit(plotType)
 
     def setAllowedPlotTypes(self, *args: PlotType) -> None:
-        """Disable all choices that are not allowed.
+        """Disable all plot type choices that are not allowed.
         If the current selection is now disabled, instead select the first
         enabled one.
 
@@ -300,10 +306,10 @@ class AutoPlotToolBar(QtWidgets.QToolBar):
 
         if comp is not self._currentComplex:
             self._currentComplex = comp
-            self.complexPolarSelected.emit(self._currentComplex)
+            self.complexRepresentationSelected.emit(self._currentComplex)
 
     def setAllowedComplexTypes(self, *complexOptions: ComplexRepresentation) -> None:
-        """Disable all choices that are not allowed.
+        """Disable all complex representation choices that are not allowed.
         If the current selection is now disabled, instead select the first
         enabled one.
         """
@@ -326,7 +332,7 @@ class AutoPlotToolBar(QtWidgets.QToolBar):
                     self._currentComplex = k
                     break
 
-            self.complexPolarSelected.emit(self._currentComplex)
+            self.complexRepresentationSelected.emit(self._currentComplex)
 
         self._currentlyAllowedComplexTypes = complexOptions
 
@@ -357,7 +363,7 @@ class AutoPlot(MPLPlotWidget):
         self.plotOptionsToolBar.plotTypeSelected.connect(
             self._plotTypeFromToolBar
         )
-        self.plotOptionsToolBar.complexPolarSelected.connect(
+        self.plotOptionsToolBar.complexRepresentationSelected.connect(
             self._complexPreferenceFromToolBar
         )
 
@@ -404,6 +410,7 @@ class AutoPlot(MPLPlotWidget):
                 self.plotOptionsToolBar.setAllowedComplexTypes(
                     ComplexRepresentation.real,
                     ComplexRepresentation.realAndImag,
+                    ComplexRepresentation.realAndImagSeparate,
                     ComplexRepresentation.magAndPhase,
                 )
             else:


### PR DESCRIPTION
This PR enables having 3 options (buttons) for complex plotting (Real, Real/Imag, Mag/Phase) to have the ability plotting only real part of complex data. The default plot is Real/Imag
The only problem is that pressing Real button plots Mag/Phase, which is wrong

Alongside this feature, it disables all complex-related buttons when the loaded data is not complex (this is also working fine)

As a side enhancement: We probably need to have Real/Imag plot to plot 2 plots (one plot for each parts of complex data) rather than combining real and imag plot in single plot.

@wpfff 